### PR TITLE
Unknown enum values

### DIFF
--- a/ejb/pom.xml
+++ b/ejb/pom.xml
@@ -19,47 +19,35 @@
             <artifactId>cdi-api</artifactId>
             <scope>provided</scope>
         </dependency>
-
         <dependency>
             <groupId>org.jboss.spec.javax.annotation</groupId>
             <artifactId>jboss-annotations-api_1.3_spec</artifactId>
             <scope>provided</scope>
         </dependency>
-
         <dependency>
             <groupId>org.jboss.spec.javax.ejb</groupId>
             <artifactId>jboss-ejb-api_3.2_spec</artifactId>
             <scope>provided</scope>
         </dependency>
-
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
         </dependency>
-
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <version>${org.projectlombok.lombok.version}</version>
         </dependency>
-
-        <!--<dependency>-->
-            <!--<groupId>org.apache.commons</groupId>-->
-            <!--<artifactId>commons-lang3</artifactId>-->
-        <!--</dependency>-->
-
         <dependency>
             <groupId>org.elasticsearch</groupId>
             <artifactId>elasticsearch</artifactId>
             <version>${elastic.version}</version>
         </dependency>
-
         <dependency>
             <groupId>net.java.dev.jna</groupId>
             <artifactId>jna</artifactId>
             <version>${es.jna.version}</version>
         </dependency>
-
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
@@ -73,6 +61,10 @@
             <artifactId>guava</artifactId>
             <version>${com.google.guava.guava.version}</version>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
         </dependency>
     </dependencies>
     <build>

--- a/ejb/src/main/java/io/whalebone/publicapi/ejb/json/LowercaseEnumTypeAdapter.java
+++ b/ejb/src/main/java/io/whalebone/publicapi/ejb/json/LowercaseEnumTypeAdapter.java
@@ -7,12 +7,17 @@ import com.google.gson.stream.JsonToken;
 import com.google.gson.stream.JsonWriter;
 import org.apache.commons.lang3.StringUtils;
 
+import javax.inject.Inject;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 public class LowercaseEnumTypeAdapter<E extends Enum<E>> extends TypeAdapter<E> {
+
+    private static final Logger logger = Logger.getLogger(LowercaseEnumTypeAdapter.class.getName());
 
     private Class<E> enumClass;
     private final Map<String, E> deserializationMap = new HashMap<>();
@@ -55,7 +60,8 @@ public class LowercaseEnumTypeAdapter<E extends Enum<E>> extends TypeAdapter<E> 
         } else {
             String value = reader.nextString();
             if (!deserializationMap.containsKey(value)) {
-                throw new IOException("Unknown enum value '" + value + "' of enum " + enumClass.getCanonicalName());
+                logger.log(Level.WARNING, "Unknown enum value \"{0}\" of enum {1}", new Object[] {value, enumClass});
+                return null;
             }
             return deserializationMap.get(value);
         }

--- a/ejb/src/main/java/io/whalebone/publicapi/ejb/json/LowercaseEnumTypeAdapter.java
+++ b/ejb/src/main/java/io/whalebone/publicapi/ejb/json/LowercaseEnumTypeAdapter.java
@@ -7,7 +7,6 @@ import com.google.gson.stream.JsonToken;
 import com.google.gson.stream.JsonWriter;
 import org.apache.commons.lang3.StringUtils;
 
-import javax.inject.Inject;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.util.HashMap;

--- a/ejb/src/test/java/io/whalebone/publicapi/ejb/elastic/DnsTimeBucketDTOProducerTest.java
+++ b/ejb/src/test/java/io/whalebone/publicapi/ejb/elastic/DnsTimeBucketDTOProducerTest.java
@@ -1,0 +1,174 @@
+package io.whalebone.publicapi.ejb.elastic;
+
+import io.whalebone.publicapi.ejb.dto.DnsAggregateBucketDTO;
+import io.whalebone.publicapi.ejb.dto.DnsTimeBucketDTO;
+import io.whalebone.publicapi.ejb.dto.EAggregate;
+import io.whalebone.publicapi.ejb.dto.EDnsQueryType;
+import org.apache.commons.collections4.CollectionUtils;
+import org.elasticsearch.common.joda.time.DateTime;
+import org.elasticsearch.common.joda.time.format.DateTimeFormat;
+import org.elasticsearch.common.joda.time.format.DateTimeFormatter;
+import org.elasticsearch.search.aggregations.Aggregations;
+import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogram;
+import org.elasticsearch.search.aggregations.bucket.terms.Terms;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+public class DnsTimeBucketDTOProducerTest {
+    private static final String TIMESTAMP_FORMAT = "yyyy-MM-dd'T'HH:mm:ssZ";
+
+    @Test
+    public void produceTest_aggregateByClientId() {
+        List<DateHistogram.Bucket> dateHistogramBuckets = new ArrayList<>(3);
+        for (int i = 0; i < 3; i++) {
+            List<Terms.Bucket> termsBuckets = new ArrayList<>(5);
+            for (int j = 0; j < 5; j++) {
+                termsBuckets.add(prepareTermsBucket("10.1.1." + j, 10 + j));
+            }
+            dateHistogramBuckets.add(prepareDateHistogramBucket("2018-01-01T14:00:0" + i + "+0000", 5 + i, termsBuckets));
+        }
+        Aggregations aggregations = prepareAggregations(dateHistogramBuckets);
+
+        DnsTimeBucketDTOProducer producer = new DnsTimeBucketDTOProducer(EAggregate.CLIENT_IP);
+        List<DnsTimeBucketDTO> buckets = producer.produce(aggregations);
+
+        assertThat(buckets, is(notNullValue()));
+        assertThat(buckets, hasSize(3));
+        for(int i = 0; i < buckets.size(); i++) {
+            java.time.format.DateTimeFormatter formatter = java.time.format.DateTimeFormatter.ofPattern(TIMESTAMP_FORMAT);
+            ZonedDateTime timestamp = ZonedDateTime.parse("2018-01-01T14:00:0" + i + "+0000", formatter);
+            assertThat(buckets.get(i).getTimestamp().toInstant().toEpochMilli(), is(timestamp.toInstant().toEpochMilli()));
+            assertThat(buckets.get(i).getCount(), is(5L + i));
+            assertThat(buckets.get(i).getBuckets(), hasSize(5));
+            for (int j = 0; j < buckets.get(i).getBuckets().size(); j++) {
+                DnsAggregateBucketDTO aggBucket = buckets.get(i).getBuckets().get(j);
+                assertThat(aggBucket.getClientIp(), is("10.1.1." + j));
+                assertThat(aggBucket.getCount(), is(10L + j));
+            }
+        }
+    }
+
+    @Test
+    public void produceTest_aggregateByQueryType() {
+        List<DateHistogram.Bucket> dateHistogramBuckets = new ArrayList<>(3);
+        List<String> aggregateKeys = Arrays.asList("aaaa", "loc", "CDNSKEY", "TXT", "unknown" /*this bucket should be dropped*/);
+        List<EDnsQueryType> expectedQueryTypes = Arrays.asList(EDnsQueryType.AAAA, EDnsQueryType.LOC,
+                EDnsQueryType.CDNSKEY, EDnsQueryType.TXT);
+        for (int i = 0; i < 3; i++) {
+            List<Terms.Bucket> termsBuckets = new ArrayList<>(5);
+            for (int j = 0; j < 5; j++) {
+                termsBuckets.add(prepareTermsBucket(aggregateKeys.get(j), 10 + j));
+            }
+            dateHistogramBuckets.add(prepareDateHistogramBucket("2018-01-01T14:00:0" + i + "+0000", 5 + i, termsBuckets));
+        }
+        Aggregations aggregations = prepareAggregations(dateHistogramBuckets);
+
+        DnsTimeBucketDTOProducer producer = new DnsTimeBucketDTOProducer(EAggregate.TYPE);
+        List<DnsTimeBucketDTO> buckets = producer.produce(aggregations);
+
+        assertThat(buckets, is(notNullValue()));
+        assertThat(buckets, hasSize(3));
+        for(int i = 0; i < buckets.size(); i++) {
+            assertThat(buckets.get(i).getBuckets(), hasSize(4));
+            for (int j = 0; j < buckets.get(i).getBuckets().size(); j++) {
+                DnsAggregateBucketDTO aggBucket = buckets.get(i).getBuckets().get(j);
+                assertThat(aggBucket.getType(), is(expectedQueryTypes.get(j)));
+            }
+        }
+    }
+
+    @Test
+    public void produceTest_aggregationNotAvailable() {
+        List<DateHistogram.Bucket> dateHistogramBuckets = new ArrayList<>(3);
+        for (int i = 0; i < 3; i++) {
+            dateHistogramBuckets.add(prepareDateHistogramBucket("2018-01-01T14:00:0" + i + "+0000", 5 + i, null));
+        }
+        Aggregations aggregations = prepareAggregations(dateHistogramBuckets);
+
+        DnsTimeBucketDTOProducer producer = new DnsTimeBucketDTOProducer(EAggregate.TYPE);
+        List<DnsTimeBucketDTO> buckets = producer.produce(aggregations);
+
+        assertThat(buckets, is(notNullValue()));
+        assertThat(buckets, hasSize(3));
+        for(int i = 0; i < buckets.size(); i++) {
+            assertThat(buckets.get(i).getBuckets(), is(nullValue()));
+        }
+    }
+
+    @DataProvider
+    public Object[][] buildAggregateBucketTestData() {
+        return new Object[][] {
+                new Object[] {EAggregate.CLIENT_IP, "1.2.3.4", "1.2.3.4", null, null, null, null, null},
+                new Object[] {EAggregate.TYPE, "aaaa", null, EDnsQueryType.AAAA, null, null, null, null},
+                new Object[] {EAggregate.TYPE, "AAAA", null, EDnsQueryType.AAAA, null, null, null, null},
+                new Object[] {EAggregate.ANSWER, "answer", null, null, "answer", null, null, null},
+                new Object[] {EAggregate.DOMAIN, "whalebone.io", null, null, null, "whalebone.io", null, null},
+                new Object[] {EAggregate.QUERY, "some.thing.whalebone.io", null, null, null, null, "some.thing.whalebone.io", null},
+                new Object[] {EAggregate.TLD, "io", null, null, null, null, null, "io"},
+        };
+    }
+
+    @Test(dataProvider = "buildAggregateBucketTestData")
+    public void buildAggregateBucketTest(EAggregate aggregateBy, String aggregationKey, String expectedClientIp,
+                                         EDnsQueryType expectedQueryType, String expectedAnswer, String expectedDomain,
+                                         String expectedQuery, String expectedTld) {
+        DnsTimeBucketDTOProducer producer = new DnsTimeBucketDTOProducer(aggregateBy);
+        Terms.Bucket termsBucket = prepareTermsBucket(aggregationKey, 42L);
+
+        DnsAggregateBucketDTO bucket = producer.buildAggregateBucket(termsBucket);
+        assertThat(bucket, is(notNullValue()));
+        assertThat(bucket.getCount(), is(42L));
+        assertThat(bucket.getClientIp(), is(expectedClientIp));
+        assertThat(bucket.getType(), is(expectedQueryType));
+        assertThat(bucket.getAnswer(), is(expectedAnswer));
+        assertThat(bucket.getDomain(), is(expectedDomain));
+        assertThat(bucket.getQuery(), is(expectedQuery));
+        assertThat(bucket.getTld(), is(expectedTld));
+    }
+
+    private Aggregations prepareAggregations(List<DateHistogram.Bucket> buckets) {
+        DateHistogram histogram = mock(DateHistogram.class);
+        doReturn(buckets).when(histogram).getBuckets();
+        Aggregations aggregations = mock(Aggregations.class);
+        doReturn(histogram).when(aggregations).get(DnsTimeBucketDTOProducer.TIME_AGGREGATION);
+        return aggregations;
+    }
+
+    private DateHistogram.Bucket prepareDateHistogramBucket(String timestamp, long count, List<Terms.Bucket> buckets) {
+        DateHistogram.Bucket bucket = mock(DateHistogram.Bucket.class);
+        DateTimeFormatter formatter = DateTimeFormat.forPattern(TIMESTAMP_FORMAT);
+        DateTime dateTime = DateTime.parse(timestamp, formatter);
+        doReturn(dateTime).when(bucket).getKeyAsDate();
+        doReturn(count).when(bucket).getDocCount();
+
+        Aggregations aggregations = mock(Aggregations.class);
+        doReturn(aggregations).when(bucket).getAggregations();
+
+        if (CollectionUtils.isNotEmpty(buckets)) {
+            Terms termsAggregation = mock(Terms.class);
+            doReturn(buckets).when(termsAggregation).getBuckets();
+            doReturn(termsAggregation).when(aggregations).get(DnsTimeBucketDTOProducer.TERM_AGGREGATION);
+        }
+        return bucket;
+    }
+
+    private Terms.Bucket prepareTermsBucket(String key, long count) {
+        Terms.Bucket bucket = mock(Terms.Bucket.class);
+        doReturn(count).when(bucket).getDocCount();
+        doReturn(key).when(bucket).getKey();
+        return bucket;
+    }
+}

--- a/ejb/src/test/java/io/whalebone/publicapi/ejb/json/LowercaseEnumTypeAdapterFactoryTest.java
+++ b/ejb/src/test/java/io/whalebone/publicapi/ejb/json/LowercaseEnumTypeAdapterFactoryTest.java
@@ -8,6 +8,7 @@ import java.io.IOException;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.testng.Assert.assertNull;
 
 public class LowercaseEnumTypeAdapterFactoryTest {
 
@@ -31,9 +32,11 @@ public class LowercaseEnumTypeAdapterFactoryTest {
         assertThat(threadType, is(EThreatType.C_AND_C));
     }
 
-    @Test(expectedExceptions = IOException.class)
+    @Test
     public void deserializationUnknownConstantTest() throws Exception {
-        adapter.fromJson("\"unknown\"");
+        EThreatType threatType = adapter.fromJson("\"unknown\"");
+
+        assertNull(threatType);
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,7 @@
         <!-- test dependencies -->
         <org.testng.testng.version>6.14.3</org.testng.testng.version>
         <org.hamcrest.java-hamcrest.version>2.0.0.0</org.hamcrest.java-hamcrest.version>
+        <org.mockito.mockito-core.version>2.23.4</org.mockito.mockito-core.version>
         <!-- arquillian test dependencies -->
         <version.arquillian_maven>1.0.0.Alpha2</version.arquillian_maven>
         <org.jboss.arquillian.arquillian-bom.version>1.2.1.Final</org.jboss.arquillian.arquillian-bom.version>
@@ -95,6 +96,12 @@
                 <version>${org.jboss.arquillian.arquillian-bom.version}</version>
                 <scope>import</scope>
                 <type>pom</type>
+            </dependency>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-core</artifactId>
+                <version>${org.mockito.mockito-core.version}</version>
+                <scope>test</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
If archive returns unknown enum value then no exception is thrown. It is considered as empty value.
If archive returns bucket aggregated by unknown query type, then the whole bucket is discarded.
Tests modified accordingly
DnsTimeBucketDTOProducerTest added.